### PR TITLE
:sparkles: adds postgresql exec script task 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,63 +20,6 @@ Or install it yourself as:
 
     $ gem install postgres_to_redshift
 
-## Usage
-
-Set your source and target databases, as well as your s3 intermediary.
-
-### postgres_to_redshift
-```bash
-export P2RS_INCREMENTAL_BLACKOUT='6' #integer value of the hour in UTC that the incremental job should not be run
-export P2RS_SOURCE_URI='postgres://username:password@host:port/database-name'
-export P2RS_SOURCE_SCHEMA='schema_name'
-export P2RS_SOURCE_TABLE='table_name|ALL' #ALL for all tables in the schema (aside from rails operational tables) eitherwise specify table name
-export P2RS_S3_EXPORT_ID='yourid'
-export P2RS_S3_EXPORT_KEY='yourkey'
-export P2RS_S3_EXPORT_BUCKET='some-bucket-to-use'
-export P2RS_TARGET_URI='postgres://username:password@host:port/database-name'
-export P2RS_TARGET_SCHEMA='schema_name'  #make sure target_schema exist in target DB
-export P2RS_DELETE_OPTION='truncate|drop|incremental' #this define whether the destination tables should be truncated or drop or batch load
-export P2RS_CONDITION_FIELD='na|column_name' #use to decide which time-series field to use for calculating incremental data load
-export P2RS_CONDITION_VALUE='na|some_number' #a number value to determine how many MINUTES we should look for last updated records
-
-postgres_to_redshift
-```
-
-### postgres_to_s3
-```bash
-export P2S3_SOURCE_URI='postgres://username:password@host:port/database-name'
-export P2S3_SOURCE_SCHEMA='schema_name'
-export P2S3_SOURCE_TABLE='table_name'
-export P2S3_S3_EXPORT_ID='yourid'
-export P2S3_S3_EXPORT_KEY='yourkey'
-export P2S3_S3_EXPORT_BUCKET='some-bucket-to-use'
-export P2S3_SERVICE_NAME='service_name in audits table'
-export P2S3_ARCHIVE_FIELD='name of the date column in the table'
-export P2S3_ARCHIVE_DATE='a date column with format YYYY-MM-DD'
-
-postgres_to_s3
-```
-
-### redshift_exec
-```bash
-export P2RS_S3_EXPORT_ID='yourid' -- same as P2RS (assumption being it is being exected on the single RS instance)
-export P2RS_S3_EXPORT_KEY='yourkey' -- same as P2RS (assumption being it is being exected on the single RS instance)
-export P2RS_TARGET_URI='postgres://username:password@host:port/database-name' -- same as P2RS (assumption being it is being exected on the single RS instance)
-
-export REXE_S3_SCRIPT_BUCKET='some-bucket-to-use'
-export REXE_S3_SCRIPT_NAME='object-name-of-the-sql-script'
-
-redshift_exec
-```
-
-### slack integration
-```bash
-export SLACK_CHANNEL
-export SLACK_USERNAME
-export SLACK_WEBHOOK_URL
-export SLACK_ON_SUCCESS='true/[anything]' -- identify whether or not to send slack msg on job success
-```
-
 ## Contributing
 
 1. Fork it ( https://github.com/kitchensurfing/postgres_to_redshift/fork)

--- a/bin/redshift_to_s3
+++ b/bin/redshift_to_s3
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require 'redshift_to_s3'
+
+RedshiftToS3.archive_tables

--- a/lib/postgres_to_redshift.rb
+++ b/lib/postgres_to_redshift.rb
@@ -138,7 +138,7 @@ class PostgresToRedshift
     end
     source_connection.exec(table_command).map do |table_attributes|
     @table = Helper::Table.new(attributes: table_attributes)
-    next if table.name =~ /^pg_/
+      next if table.name =~ /^pg_/
       table.columns = column_definitions(table)
       table
     end.compact

--- a/lib/postgres_to_s3.rb
+++ b/lib/postgres_to_s3.rb
@@ -144,7 +144,7 @@ class PostgresToS3
       tmpfile.rewind
       upload_table(table, tmpfile, chunk, timestamp)
       if (PostgresToS3.slack_on_success == 'true')
-        message = "[P2S3]SUCCESS: Archived #{PostgresToS3.service_name}/#{PostgresToS3.service_name}-#{PostgresToS3.archive_date}-#{table.target_table_name} | Total Chunk(s): #{chunk} | SERVICE: #{PostgresToS3.service_name} | TABLE: #{PostgresToS3.source_table} | DATE: #{PostgresToS3.archive_date}"
+        message = "[P2S3]SUCCESS: Archived #{PostgresToS3.service_name}/#{PostgresToS3.service_name}-#{table.target_table_name}-#{PostgresToS3.archive_date} | Total Chunk(s): #{chunk} | SERVICE: #{PostgresToS3.service_name} | TABLE: #{PostgresToS3.source_table} | DATE: #{PostgresToS3.archive_date}"
         SLACK_NOTIFIER.ping message
       end
       source_connection.reset
@@ -155,12 +155,12 @@ class PostgresToS3
   end
 
   def upload_table(table, buffer, chunk, timestamp)
-    #puts "UPLOADING #{PostgresToS3.service_name}/#{PostgresToS3.service_name}-#{PostgresToS3.archive_date}-#{table.target_table_name}-#{timestamp}.psv.gz.#{chunk}"
+    #puts "UPLOADING #{PostgresToS3.service_name}/#{PostgresToS3.service_name}-#{table.target_table_name}-#{PostgresToS3.archive_date}-#{timestamp}.psv.gz.#{chunk}"
 
-    bucket.objects["#{PostgresToS3.service_name}/#{PostgresToS3.service_name}-#{PostgresToS3.archive_date}-#{table.target_table_name}-#{timestamp}.psv.gz.#{chunk}"].write(buffer, acl: :authenticated_read)
+    bucket.objects["#{PostgresToS3.service_name}/#{PostgresToS3.service_name}-#{table.target_table_name}-#{PostgresToS3.archive_date}-#{timestamp}.psv.gz.#{chunk}"].write(buffer, acl: :authenticated_read)
 
     if (PostgresToS3.slack_on_success == 'true')
-      message = "[P2S3]FINISH: Archived #{PostgresToS3.service_name}/#{PostgresToS3.service_name}-#{PostgresToS3.archive_date}-#{table.target_table_name}-#{timestamp}.psv.gz.#{chunk}"
+      message = "[P2S3]FINISH: Archived #{PostgresToS3.service_name}/#{PostgresToS3.service_name}-#{table.target_table_name}-#{PostgresToS3.archive_date}-#{timestamp}.psv.gz.#{chunk}"
       SLACK_NOTIFIER.ping message
     end
   end

--- a/lib/redshift_to_s3.rb
+++ b/lib/redshift_to_s3.rb
@@ -1,0 +1,150 @@
+require "helper/version"
+require 'pg'
+require 'uri'
+require 'aws-sdk-v1'
+require 'slack-notifier'
+require 'zlib'
+require 'tempfile'
+require "helper/table"
+require "helper/column"
+require "helper/slack_notifier"
+require "pry-rails"
+
+class RedshiftToS3
+  class << self
+    attr_accessor :source_uri, :source_schema, :source_table, :archive_date
+  end
+
+  attr_reader :source_connection, :s3
+
+  KILOBYTE = 1024
+  MEGABYTE = KILOBYTE * 1024
+  GIGABYTE = MEGABYTE * 1024
+
+  def self.archive_tables
+    archive_tables = RedshiftToS3.new
+    if archive_tables.tables.size == 0
+      message = "[RS2S3]MISSING: Table(s) not found using the following parameters:\n[RS2S3]MISSING: source_schema: #{ENV["RS2S3_SOURCE_SCHEMA"]}\n[RS2S3]MISSING: source_table: #{ENV["RS2S3_SOURCE_TABLE"]}"
+      SLACK_NOTIFIER.ping message
+    end
+    archive_tables.tables.each do |table|
+      archive_tables.copy_table(table)
+    end
+  rescue => e
+    SLACK_NOTIFIER.ping "[RS2S3]#{e.message.gsub("\r"," ").gsub("\n"," ")} | SCHEMA: #{RedshiftToS3.source_schema} | TABLE: #{RedshiftToS3.source_table} | DATE: #{RedshiftToS3.archive_date}"
+  end
+
+  def self.source_uri
+    @source_uri ||= URI.parse(ENV['RS2S3_SOURCE_URI'])
+  end
+
+  def self.source_schema
+    @source_schema ||= ENV['RS2S3_SOURCE_SCHEMA']
+  end
+
+  def self.source_table
+    @source_table ||= ENV['RS2S3_SOURCE_TABLE']
+  end
+
+  def self.archive_date
+    @archive_date ||= Time.now.strftime("%F")
+  end
+
+  def self.source_connection
+    unless instance_variable_defined?(:"@source_connection")
+      @source_connection = PG::Connection.new(host: source_uri.host, port: source_uri.port, user: source_uri.user || ENV['USER'], password: source_uri.password, dbname: source_uri.path[1..-1])
+      @source_connection.exec("SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY;")
+    end
+
+    @source_connection
+  end
+
+  def source_connection
+    self.class.source_connection
+  end
+
+  def self.slack_on_success
+    @slack_on_success ||= ENV['SLACK_ON_SUCCESS']
+  end
+
+  def tables
+    table_command = <<-SQL
+      SELECT t.*
+      FROM information_schema.tables t
+      WHERE t.table_schema = '#{RedshiftToS3.source_schema}' AND t.table_name = '#{RedshiftToS3.source_table}'
+    SQL
+    source_connection.exec(table_command).map do |table_attributes|
+    table = Helper::Table.new(attributes: table_attributes)
+      next if table.name =~ /^pg_/
+      table.columns = column_definitions(table)
+      table
+    end.compact
+  end
+
+  def column_definitions(table)
+    column_command = <<-SQL
+      SELECT *
+      FROM information_schema.columns
+      WHERE table_schema = '#{RedshiftToS3.source_schema}' AND table_name='#{table.name}'
+      ORDER BY ordinal_position
+    SQL
+    source_connection.exec(column_command)
+  end
+
+  def s3
+    @s3 ||= AWS::S3.new(access_key_id: ENV['RS2S3_S3_EXPORT_ID'], secret_access_key: ENV['RS2S3_S3_EXPORT_KEY'])
+  end
+
+  def bucket
+    @bucket ||= s3.buckets[ENV['RS2S3_S3_EXPORT_BUCKET']]
+  end
+
+  def copy_table(table)
+    tmpfile = Tempfile.new("rd2s3")
+    zip = Zlib::GzipWriter.new(tmpfile)
+    chunksize = 5 * GIGABYTE # uncompressed
+    chunk = 1
+    timestamp = Time.now.to_i
+
+    begin
+      copy_to_command = <<-SQL
+          SELECT *
+          FROM #{RedshiftToS3.source_schema}.#{table.name}
+      SQL
+      source_connection.exec(copy_to_command).each do |row|
+        formatted_row = row.values.map { |a| a.nil? ? "\\N" : a.gsub("|", "\\|") }.join("|")
+        zip.write(formatted_row += "\n")
+        if (zip.pos > chunksize)
+          zip.finish
+          tmpfile.rewind
+          upload_table(table, tmpfile, chunk, timestamp)
+          chunk += 1
+          zip.close unless zip.closed?
+          tmpfile.unlink
+          tmpfile = Tempfile.new("rd2s3")
+          zip = Zlib::GzipWriter.new(tmpfile)
+        end
+      end
+      zip.finish
+      tmpfile.rewind
+      upload_table(table, tmpfile, chunk, timestamp)
+      if (RedshiftToS3.slack_on_success == 'true')
+        message = "[RS2S3]SUCCESS: Archived #{RedshiftToS3.source_schema}/#{RedshiftToS3.source_schema}-#{RedshiftToS3.archive_date}-#{table.target_table_name} | Total Chunk(s): #{chunk} | SCHEMA: #{RedshiftToS3.source_schema} | TABLE: #{RedshiftToS3.source_table} | DATE: #{RedshiftToS3.archive_date}"
+        SLACK_NOTIFIER.ping message
+      end
+      source_connection.reset
+    ensure
+      zip.close unless zip.closed?
+      tmpfile.unlink
+    end
+  end
+
+  def upload_table(table, buffer, chunk, timestamp)
+    bucket.objects["#{RedshiftToS3.source_schema}/#{RedshiftToS3.source_schema}-#{RedshiftToS3.archive_date}-#{table.target_table_name}-#{timestamp}.psv.gz.#{chunk}"].write(buffer, acl: :authenticated_read)
+
+    if (RedshiftToS3.slack_on_success == 'true')
+      message = "[RS2S3]FINISH: Archived #{RedshiftToS3.source_schema}/#{RedshiftToS3.source_schema}-#{RedshiftToS3.archive_date}-#{table.target_table_name}-#{timestamp}.psv.gz.#{chunk}"
+      SLACK_NOTIFIER.ping message
+    end
+  end
+end

--- a/lib/redshift_to_s3.rb
+++ b/lib/redshift_to_s3.rb
@@ -52,7 +52,7 @@ class RedshiftToS3
 
   def self.source_connection
     unless instance_variable_defined?(:"@source_connection")
-      @source_connection = PG::Connection.new(host: source_uri.host, port: source_uri.port, user: source_uri.user || ENV['USER'], password: source_uri.password, dbname: source_uri.path[1..-1])
+      @source_connection = PG::Connection.new(host: source_uri.host, port: source_uri.port, user: source_uri.user || ENV['USER'], password: URI.decode(source_uri.password), dbname: source_uri.path[1..-1])
       @source_connection.exec("SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY;")
     end
 
@@ -129,7 +129,7 @@ class RedshiftToS3
       tmpfile.rewind
       upload_table(table, tmpfile, chunk, timestamp)
       if (RedshiftToS3.slack_on_success == 'true')
-        message = "[RS2S3]SUCCESS: Archived #{RedshiftToS3.source_schema}/#{RedshiftToS3.source_schema}-#{RedshiftToS3.archive_date}-#{table.target_table_name} | Total Chunk(s): #{chunk} | SCHEMA: #{RedshiftToS3.source_schema} | TABLE: #{RedshiftToS3.source_table} | DATE: #{RedshiftToS3.archive_date}"
+        message = "[RS2S3]SUCCESS: Archived #{RedshiftToS3.source_schema}/#{RedshiftToS3.source_schema}-#{table.target_table_name}-#{RedshiftToS3.archive_date} | Total Chunk(s): #{chunk} | SCHEMA: #{RedshiftToS3.source_schema} | TABLE: #{RedshiftToS3.source_table} | DATE: #{RedshiftToS3.archive_date}"
         SLACK_NOTIFIER.ping message
       end
       source_connection.reset
@@ -140,10 +140,10 @@ class RedshiftToS3
   end
 
   def upload_table(table, buffer, chunk, timestamp)
-    bucket.objects["#{RedshiftToS3.source_schema}/#{RedshiftToS3.source_schema}-#{RedshiftToS3.archive_date}-#{table.target_table_name}-#{timestamp}.psv.gz.#{chunk}"].write(buffer, acl: :authenticated_read)
+    bucket.objects["#{RedshiftToS3.source_schema}/#{RedshiftToS3.source_schema}-#{table.target_table_name}-#{RedshiftToS3.archive_date}-#{timestamp}.psv.gz.#{chunk}"].write(buffer, acl: :authenticated_read)
 
     if (RedshiftToS3.slack_on_success == 'true')
-      message = "[RS2S3]FINISH: Archived #{RedshiftToS3.source_schema}/#{RedshiftToS3.source_schema}-#{RedshiftToS3.archive_date}-#{table.target_table_name}-#{timestamp}.psv.gz.#{chunk}"
+      message = "[RS2S3]FINISH: Archived #{RedshiftToS3.source_schema}/#{RedshiftToS3.source_schema}-#{table.target_table_name}-#{RedshiftToS3.archive_date}-#{timestamp}.psv.gz.#{chunk}"
       SLACK_NOTIFIER.ping message
     end
   end

--- a/postgres_to_redshift.gemspec
+++ b/postgres_to_redshift.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk-v1", "~> 1.54"
   spec.add_dependency "slack-notifier", "~>1.5.1"
 
-  spec.executables   = ["postgres_to_redshift", "postgres_to_s3", "redshift_exec"]
+  spec.executables   = ["postgres_to_redshift", "postgres_to_s3", "redshift_exec", "redshift_to_s3"]
 end


### PR DESCRIPTION
It's the same code as in redshift exec script but using a different env var for the HOST, allowing to specify for example a Postgres URI.