### PR TITLE
:bug: low numeric scale when creating target table

### DIFF
--- a/lib/helper/column.rb
+++ b/lib/helper/column.rb
@@ -60,7 +60,7 @@ class Helper::Column
     "time" => "CHARACTER VARYING(65535)",
     "inet" => "CHARACTER VARYING(65535)",
     "uuid" => "CHARACTER VARYING(65535)",
-    "numeric" => "NUMERIC(18,4)",
+    "numeric" => "NUMERIC(38,12)",
   }
 
   def initialize(attributes: )


### PR DESCRIPTION
The gem was using a NUMERIC(18,4) datatype for all numeric columns when generating the CREATE TABLE when we were losing precision in Redshift because of that. I've increased it to NUMERIC(38,12).